### PR TITLE
fix: adding /workspace as safe directory for git #9

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -16,3 +16,10 @@ bun install
 bun next telemetry disable
 bun add next react react-dom
 bunx commitizen init cz-conventional-changelog --save-dev --save-exact
+
+if [[ -d /workspace/.git ]]; then
+  echo "Setting safe.directory for git..."
+  git config --global --add safe.directory /workspace || echo "git config safe.directory failed, but continuing..."
+else
+  echo "No .git directory found in /workspace, skipping git safe.directory configuration."
+fi

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -19,7 +19,11 @@ bunx commitizen init cz-conventional-changelog --save-dev --save-exact
 
 if [[ -d /workspace/.git ]]; then
   echo "Setting safe.directory for git..."
-  git config --global --add safe.directory /workspace || echo "git config safe.directory failed, but continuing..."
+  if ! git config --get-all safe.directory | grep -qx "/workspace"; then
+    git config --global --add safe.directory /workspace || echo "git config safe.directory failed, but continuing..."
+  else
+    echo "/workspace is already listed as a safe.directory."
+  fi
 else
   echo "No .git directory found in /workspace, skipping git safe.directory configuration."
 fi


### PR DESCRIPTION
Merge main down to github branch and added the safe.directory for git.config
so that we can use source control menu on vscode and don't get the error message: 
```
2025-06-04 19:02:09.505 [error] [GitHistoryProvider][provideHistoryItems] Failed to get history items with options '{"historyItemRefs":["f64370f15fb398f12a2b456ced3068c9fe0532ff","f64370f15fb398f12a2b456ced3068c9fe0532ff"],"limit":50,"skip":0}': Failed to execute git {
  "exitCode": 128,
  "gitCommand": "log",
  "stdout": "",
  "stderr": "fatal: detected dubious ownership in repository at '/workspace'\nTo add an exception for this directory, call:\n\n\tgit config --global --add safe.directory /workspace\n"
}
```